### PR TITLE
Added "flip-link" dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,14 +191,16 @@ the language.
 Microgroove requires Rust nightly (it uses the
 [linked_list_allocator](https://crates.io/crates/linked_list_allocator) crate, which requires the
 `AllocRef` trait only in the nightly API). You'll also need to install the `thumbv6m-none-eabi`
-target, which allows compilation for the Pi Pico's ARM Cortex-M0+ CPU, and
+target, which allows compilation for the Pi Pico's ARM Cortex-M0+ CPU, 
 [cargo-embed](https://crates.io/crates/cargo-embed) which extends `cargo` with an `embed` command to
-flash binaries to embedded devices.
+flash binaries to embedded devices, and [flip-link](https://github.com/knurling-rs/flip-link), a 
+linker that helps protect embedded program from stack overflow.
 
 ```
 $ rustup toolchain install nightly
 $ rustup target add thumbv6m-none-eabi
 $ cargo install cargo-embed
+$ cargo install flip-link
 ```
 
 You can check your setup by running the `microgroove_sequencer` crate's unit tests.


### PR DESCRIPTION
Currently "microgroove_app" builds will error:
```
>cargo embed
   Compiling microgroove_app v0.3.0 (/Users/drzlo/work/sound/microgroove/firmware/microgroove_app)
error: could not compile `microgroove_app` (bin "microgroove_app") due to 2 previous errors
error: linker `flip-link` not found
  |
  = note: No such file or directory (os error 2)

error: aborting due to 1 previous error

       Error Failed to run cargo build: exit code = Some(101).
```

This PR adds "flip-link" to the prerequisites in readme.